### PR TITLE
Build and publish Docker image in GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
+      - dev
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.9-slim
 
+LABEL version="2021" \
+    description="Vaalilakanabot" \
+    org.opencontainers.image.source="https://github.com/fyysikkokilta/vaalilakanabot"
+
 WORKDIR /bot
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
   bot:
     build: .
-    image: vaalilakanabot:latest
+    image: ghcr.io/fyysikkokilta/vaalilakanabot:master
     volumes:
       - ./data:/bot/data:rw
       - ./logs:/bot/logs:rw


### PR DESCRIPTION
Builds and publishes Dockerfile as `ghcr.io/fyysikkokilta/vaalilakanabot`. Tag is inferred magically using docker/metadata-action@v3.

This should allow updating and deploying the bot without building using
```bash
docker-compose pull && docker-compose up -d
```